### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: adopt
+          distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,17 @@
 name: Java CI
-
-on: [push, pull_request]
-
+on:
+  - push
+  - pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: adopt
           cache: gradle
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
This PR updates GitHub Actions versions:
- actions/checkout from v2 to v4
- actions/setup-java from v2 to v4